### PR TITLE
Add missing var declaration

### DIFF
--- a/combinatorics.js
+++ b/combinatorics.js
@@ -147,8 +147,8 @@
             next: function() {
                 if (this.index >= maxIndex) return;
                 var i = 0,
-                    n = this.index;
-                result = [];
+                    n = this.index,
+                    result = [];
                 for (; n; n >>>= 1, i++) if (n & 1) result.push(this[i]);
                 this.index = nextIndex(this.index);
                 return result;


### PR DESCRIPTION
After executing `Combinatorics.combination(array, num).next()`, `result` leaks into global scope.

``` js
var Combinatorics = require('./combinatorics.js').Combinatorics;
console.log(Combinatorics.combination([ 1, 2, 3 ], 2).next()); // [ 1, 2 ]
console.log(result); // [ 1, 2 ]
```
