### PR TITLE
Fix example for lazyFilter in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ For example, you can redefine combination as follows:
 
 ````
 myCombination = function(ary, n) {
-  return Combinatorics.power(ary).filter(function (a) {
+  return Combinatorics.power(ary).lazyFilter(function (a) {
     return a.length === n;
-  });
+  }).toArray();
 };
 ````
 


### PR DESCRIPTION
The example is currently a direct copy of .filter

This fixes that.