### PR TITLE
Bugfix no combination

### DIFF
--- a/combinatorics.js
+++ b/combinatorics.js
@@ -32,6 +32,9 @@
         return p;
     };
     var C = function(m, n) {
+        if (n > m) {
+            return 0;
+        }
         return P(m, n) / P(n, n);
     };
     var factorial = function(n) {

--- a/combinatorics.js
+++ b/combinatorics.js
@@ -22,12 +22,7 @@
     var version = "0.5.1";
     /* combinatory arithmetics */
     var P = function(m, n) {
-        var t, p = 1;
-        if (m < n) {
-            t = m;
-            m = n;
-            n = t;
-        }
+        var p = 1;
         while (n--) p *= m--;
         return p;
     };

--- a/test/C.js
+++ b/test/C.js
@@ -1,0 +1,23 @@
+/*
+ * use mocha to test me
+ * http://visionmedia.github.com/mocha/
+ */
+var assert, Combinatorics;
+if (this['window'] !== this) {
+    assert = require("assert");
+    Combinatorics = require('../.');
+}
+
+describe('Combinatorics.C', function () {
+    it('[3, 2] should equal 3', function() {
+        assert.equal(Combinatorics.C(3, 2), 3);
+    });
+
+    it('[1, 1] should equal 1', function() {
+        assert.equal(Combinatorics.C(1, 1), 1);
+    });
+
+    it('[2, 5] should equal 0', function() {
+        assert.equal(Combinatorics.C(2, 5), 0);
+    });
+});

--- a/test/P.js
+++ b/test/P.js
@@ -1,0 +1,23 @@
+/*
+ * use mocha to test me
+ * http://visionmedia.github.com/mocha/
+ */
+var assert, Combinatorics;
+if (this['window'] !== this) {
+    assert = require("assert");
+    Combinatorics = require('../.');
+}
+
+describe('Combinatorics.P', function () {
+    it('[3, 2] should equal 6', function() {
+        assert.equal(Combinatorics.P(3, 2), 6);
+    });
+
+    it('[1, 1] should equal 1', function() {
+        assert.equal(Combinatorics.P(1, 1), 1);
+    });
+
+    it('[2, 5] should equal 0', function() {
+        assert.equal(Combinatorics.P(2, 5), 0);
+    });
+});


### PR DESCRIPTION
`Combinatorics.C` and `Combinatorics.P` should return 0 if no possible combination/permutation (i.e. when k > n).