### PR TITLE
Fixing mocha dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "mocha"
   },
   "devDependencies": {
-    "mocha": "*"
+    "mocha": "2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Mocha 3+ doesn't accept arbitrary objects as the titles of the test-cases. Tests of js-combinatorics are using objects for titles a lot. So, the tests cannot be run on Mocha 3+.