### PR TITLE
Permutation fix for 31 elements or more - closes #34

### DIFF
--- a/combinatorics.js
+++ b/combinatorics.js
@@ -332,7 +332,13 @@
                 return size;
             },
             init: function() {
-                this.cmb = combination(ary, nelem);
+                /* combination can only be used for less than 31 elements */
+                if (ary.length < 31) {
+                    this.cmb = combination(ary, nelem);
+                } else {
+                    this.cmb = bigCombination(ary, nelem);
+                }
+                
                 this.per = _permutation(this.cmb.next());
             },
             next: function() {


### PR DESCRIPTION
This pull request fixes the `permutation()` function's behaviour for 31 elements or more by utilizing the `bigCombination()` function when necessary.

Fixes #34.