### PR TITLE
Fixes #52 (infinite loop for fractional numbers)

### DIFF
--- a/combinatorics.js
+++ b/combinatorics.js
@@ -328,6 +328,7 @@
         if (!nelem) nelem = ary.length;
         if (nelem < 1) throw new RangeError;
         if (nelem > ary.length) throw new RangeError;
+        if (nelem % 1 !== 0) throw new RangeError;
         var size = P(ary.length, nelem),
             sizeOf = function() {
                 return size;

--- a/test/permutation.js
+++ b/test/permutation.js
@@ -48,6 +48,13 @@ describe('Combinatorics.permutation', function () {
     IT(c + 0, is_deeply(c + 0, c.toArray().length));
     IT(c.length, is_deeply(c.length, c.toArray().length));
 
+    // Testing `RangeError` for fractional `nelem`
+    IT([a, [1.5, 2.25, 7.81], "should throw `RangeError`"], function() {
+        assert.throws(function() { Combinatorics.permutation(a, 1.5) }, RangeError);
+        assert.throws(function() { Combinatorics.permutation(a, 2.25) }, RangeError);
+        assert.throws(function() { Combinatorics.permutation(a, 7.81) }, RangeError);
+    });
+    
     // Testing lazy filter
     c = Combinatorics.permutation(a, 2).lazyFilter(function(a){ 
         return a[0] === 'a'


### PR DESCRIPTION
I added a check for fractional numbers to the `permutation` function:

```js
if (nelem % 1 !== 0) throw new RangeError;
```
It (`P` function line 26) would otherwise enter an infinite loop for e.g. `nelem = 1.5`.

I added tests for this case, too.

@dankogai could you please review this PR? Thanks! :relaxed: 