### PR TITLE
Fixes #52 - Infinite loop

### DIFF
--- a/combinatorics.js
+++ b/combinatorics.js
@@ -329,7 +329,6 @@
         if (!nelem) nelem = ary.length;
         if (nelem < 1) throw new RangeError;
         if (nelem > ary.length) throw new RangeError;
-        if (nelem % 1 !== 0) throw new RangeError;
         var size = P(ary.length, nelem),
             sizeOf = function() {
                 return size;

--- a/combinatorics.js
+++ b/combinatorics.js
@@ -19,9 +19,10 @@
     }
 }(this, function () {
     'use strict';
-    var version = "0.5.3";
+    var version = "0.5.4";
     /* combinatory arithmetics */
     var P = function(m, n) {
+        if (n % 1 !== 0) throw new RangeError;
         var p = 1;
         while (n--) p *= m--;
         return p;
@@ -328,6 +329,7 @@
         if (!nelem) nelem = ary.length;
         if (nelem < 1) throw new RangeError;
         if (nelem > ary.length) throw new RangeError;
+        if (nelem % 1 !== 0) throw new RangeError;
         var size = P(ary.length, nelem),
             sizeOf = function() {
                 return size;

--- a/test/C.js
+++ b/test/C.js
@@ -20,4 +20,8 @@ describe('Combinatorics.C', function () {
     it('[2, 5] should equal 0', function() {
         assert.equal(Combinatorics.C(2, 5), 0);
     });
+
+    it('[5, 1.5] should throw `RangeError`', function() {
+        assert.throws(function() { Combinatorics.C(5, 1.5) }, RangeError);
+    });
 });

--- a/test/P.js
+++ b/test/P.js
@@ -20,4 +20,8 @@ describe('Combinatorics.P', function () {
     it('[2, 5] should equal 0', function() {
         assert.equal(Combinatorics.P(2, 5), 0);
     });
+
+    it('[5, 1.5] should throw `RangeError`', function() {
+        assert.throws(function() { Combinatorics.P(5, 1.5) }, RangeError);
+    });
 });

--- a/test/combination.js
+++ b/test/combination.js
@@ -157,4 +157,9 @@ describe('Combinatorics.combination', function () {
         ["a", "c", "d", "e", "f"],
         ["b", "c", "d", "e", "f"]
     ]));
+
+    // Testing `RangeError` for fractional `nelem`
+    IT([a, 1.5, "should throw `RangeError`"], function() {
+        assert.throws(function() { Combinatorics.combination(a, 1.5) }, RangeError);
+    });
 });

--- a/test/factoradic.js
+++ b/test/factoradic.js
@@ -1,0 +1,33 @@
+/*
+ * use mocha to test me
+ * http://visionmedia.github.com/mocha/
+ */
+var assert, Combinatorics;
+if (this['window'] !== this) {
+    assert = require("assert");
+    Combinatorics = require('../.');
+}
+
+describe('Combinatorics.factoradic', function () {
+    it('1 should equal [0, 1]', function() {
+        var expected = [0, 1];
+        var actual = Combinatorics.factoradic(1);
+        assert.equal(JSON.stringify(actual), JSON.stringify(expected));
+    });
+
+    it('5 should equal [0, 1, 2]', function() {
+        var expected = [0, 1, 2];
+        var actual = Combinatorics.factoradic(5);
+        assert.equal(JSON.stringify(actual), JSON.stringify(expected));
+    });
+
+    it('[25, 1] should equal [0, 25]', function() {
+        var expected = [0, 25];
+        var actual = Combinatorics.factoradic(25, 1);
+        assert.equal(JSON.stringify(actual), JSON.stringify(expected));
+    });
+
+    it('[1, 1.5] should throw `RangeError`', function() {
+        assert.throws(function() { Combinatorics.factoradic(1, 1.5) }, RangeError);
+    });
+});

--- a/test/factorial.js
+++ b/test/factorial.js
@@ -1,0 +1,27 @@
+/*
+ * use mocha to test me
+ * http://visionmedia.github.com/mocha/
+ */
+var assert, Combinatorics;
+if (this['window'] !== this) {
+    assert = require("assert");
+    Combinatorics = require('../.');
+}
+
+describe('Combinatorics.factorial', function () {
+    it('0 should equal 1', function() {
+        assert.equal(Combinatorics.factorial(0), 1);
+    });
+
+    it('1 should equal 1', function() {
+        assert.equal(Combinatorics.factorial(1), 1);
+    });
+
+    it('4 should equal 24', function() {
+        assert.equal(Combinatorics.factorial(4), 24);
+    });
+
+    it('1.5 should throw `RangeError`', function() {
+        assert.throws(function() { Combinatorics.factorial(1.5) }, RangeError);
+    });
+});

--- a/test/permutation.js
+++ b/test/permutation.js
@@ -172,4 +172,9 @@ describe('Combinatorics.permutation', function () {
         ["c", "d"],
         ["d", "c"]
     ]));
+
+    // Testing `RangeError` for fractional `nelem`
+    IT([a, 1.5, "should throw `RangeError`"], function() {
+        assert.throws(function() { Combinatorics.permutation(a, 1.5) }, RangeError);
+    });
 });


### PR DESCRIPTION
Some functions enter an infinite loop if applied with factorial numbers. This PR should fix this.

Specifically, the `P` function will not leave its loop if `n` is a number >1 that's a factorial number (`1.1, 3.5, 6.87, ...`).

Now, with this PR, it will throw `RangeError` if `n` is a factorial number.

Further, I added tests where needed as well as added new test suits for `factorial` and `factoradic`.