### PR TITLE
Add CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ SYNOPSIS
 --------
 
 ### In Browser
-````
+```html
 <script src="combinatorics.js"></script>
-````
+<-- or include it directly via CDN -->
+<script src="https://cdn.jsdelivr.net/npm/js-combinatorics@0.5"></script>
+```
 ### node.js
 ````
 var Combinatorics = require('js-combinatorics');


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as it is the same as downloading it but easier and faster.