### PR TITLE
fix: exclude ts sources from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "description": "Simple combinatorics like power set, combination, and permutation in JavaScript",
   "main": "combinatorics.js",
   "module": "combinatorics.js",
+  "types": "combinatorics.d.ts",
   "files": [
-      "combinatorics.ts",
-      "combinatorics.d.ts",
-      "combinatorics.js"
+    "combinatorics.d.ts",
+    "combinatorics.js"
   ],
   "runkitExample": "require=require(\"esm\")(module);\nvar Combinatorics=require(\"js-combinatorics\");\n",
   "devDependencies": {
-    "typescript" : "^3.9.7",
-    "@types/node" : "^14.0.26",
+    "typescript": "^3.9.7",
+    "@types/node": "^14.0.26",
     "mocha": "^8.0.0",
     "chai": "^4.2.0"
   },


### PR DESCRIPTION
This resolves errors with included ts sources when importing library. This can't be fixed with `exclude` option in tsconfig.

https://github.com/dankogai/js-combinatorics/issues/66#issuecomment-664185038_