### PR TITLE
Use generics in typing classes

### DIFF
--- a/combinatorics.d.ts
+++ b/combinatorics.d.ts
@@ -68,7 +68,7 @@ export declare function randomInteger(min?: anyint, max?: anyint): any;
 /**
  * Base Class of `js-combinatorics`
  */
-declare class _CBase {
+declare class _CBase<T, U> {
     /**
      * does `new`
      * @param args
@@ -83,11 +83,11 @@ declare class _CBase {
     /**
      * Common iterator
      */
-    [Symbol.iterator](): Generator<any[], void, unknown>;
+    [Symbol.iterator](): Generator<U[], void, unknown>;
     /**
      * returns `[...this]`.
      */
-    toArray(): any[][];
+    toArray(): U[][];
     /**
      * tells wether you need `BigInt` to access all elements.
      */
@@ -107,11 +107,11 @@ declare class _CBase {
      * get the `n`th element of the iterator.
      * negative `n` goes backwards
      */
-    nth(n: anyint): Optional<any[]>;
+    nth(n: anyint): Optional<U[]>;
     /**
      * the seed iterable
      */
-    seed: any[];
+    seed: T[];
     /**
      * the size (# of elements) of each element.
      */
@@ -123,25 +123,25 @@ declare class _CBase {
     /**
      * pick random element
      */
-    sample(): Optional<any[]>;
+    sample(): Optional<U[]>;
     /**
      * an infinite steam of random elements
      */
-    samples(): Generator<any[], never, unknown>;
+    samples(): Generator<U[], never, unknown>;
 }
 /**
  * Permutation
  */
-export declare class Permutation extends _CBase {
-    constructor(seed: Iterable<any>, size?: number);
-    nth(n: anyint): Optional<any[]>;
+export declare class Permutation<T> extends _CBase<T, T> {
+    constructor(seed: Iterable<T>, size?: number);
+    nth(n: anyint): Optional<T[]>;
 }
 /**
  * Combination
  */
-export declare class Combination extends _CBase {
+export declare class Combination<T> extends _CBase<T, T> {
     comb: (anyint: any) => number[];
-    constructor(seed: Iterable<any>, size?: number);
+    constructor(seed: Iterable<T>, size?: number);
     /**
      * returns an iterator which is more efficient
      * than the default iterator that uses .nth
@@ -149,28 +149,28 @@ export declare class Combination extends _CBase {
      * @link https://en.wikipedia.org/wiki/Combinatorial_number_system#Applications
      */
     bitwiseIterator(): Generator<any[], void, unknown>;
-    nth(n: anyint): Optional<any[]>;
+    nth(n: anyint): Optional<T[]>;
 }
 /**
  * Base N
  */
-export declare class BaseN extends _CBase {
+export declare class BaseN<T> extends _CBase<T, T> {
     base: number;
-    constructor(seed: Iterable<any>, size?: number);
-    nth(n: anyint): Optional<any[]>;
+    constructor(seed: Iterable<T>, size?: number);
+    nth(n: anyint): Optional<T[]>;
 }
 /**
  * Power Set
  */
-export declare class PowerSet extends _CBase {
-    constructor(seed: Iterable<any>);
-    nth(n: anyint): Optional<any[]>;
+export declare class PowerSet<T> extends _CBase<T, T> {
+    constructor(seed: Iterable<T>);
+    nth(n: anyint): Optional<T[]>;
 }
 /**
  * Cartesian Product
  */
-export declare class CartesianProduct extends _CBase {
-    constructor(...args: Iterable<any>[]);
-    nth(n: anyint): Optional<any[]>;
+export declare class CartesianProduct<T> extends _CBase<T[], T> {
+    constructor(...args: Iterable<T>[]);
+    nth(n: anyint): Optional<T[]>;
 }
 export {};

--- a/combinatorics.ts
+++ b/combinatorics.ts
@@ -158,7 +158,7 @@ export function randomInteger(min: anyint = 0, max: anyint = Math.pow(2, 53)) {
 /**
  * Base Class of `js-combinatorics`
  */
-class _CBase {
+class _CBase<T, U> {
     /**
      * does `new`
      * @param args
@@ -218,11 +218,11 @@ class _CBase {
      * get the `n`th element of the iterator.
      * negative `n` goes backwards
      */
-    nth(n: anyint): Optional<any[]> { return [] };
+    nth(n: anyint): Optional<U[]> { return [] };
     /**
      * the seed iterable
      */
-    seed: any[];
+    seed: T[];
     /**
      * the size (# of elements) of each element.
      */
@@ -234,7 +234,7 @@ class _CBase {
     /**
      * pick random element
      */
-    sample(): Optional<any[]> {
+    sample(): Optional<U[]> {
         return this.nth(randomInteger(this.length));
     }
     /**
@@ -249,15 +249,15 @@ class _CBase {
 /**
  * Permutation
  */
-export class Permutation extends _CBase {
-    constructor(seed: Iterable<any>, size = 0) {
+export class Permutation<T> extends _CBase<T, T> {
+    constructor(seed: Iterable<T>, size = 0) {
         super();
         this.seed = [...seed];
         this.size = 0 < size ? size : this.seed.length;
         this.length = permutation(this.seed.length, this.size);
         Object.freeze(this);
     }
-    nth(n: anyint): Optional<any[]> {
+    nth(n: anyint): Optional<T[]> {
         n = this._check(n);
         if (n === undefined) return undefined;
         const offset = this.seed.length - this.size;
@@ -274,9 +274,9 @@ export class Permutation extends _CBase {
 /**
  * Combination
  */
-export class Combination extends _CBase {
+export class Combination<T> extends _CBase<T, T> {
     comb: (anyint) => number[];
-    constructor(seed: Iterable<any>, size = 0) {
+    constructor(seed: Iterable<T>, size = 0) {
         super();
         this.seed = [...seed];
         this.size = 0 < size ? size : this.seed.length;
@@ -312,7 +312,7 @@ export class Combination extends _CBase {
             }
         }(this, this.length);
     }
-    nth(n: anyint): Optional<any[]> {
+    nth(n: anyint): Optional<T[]> {
         n = this._check(n);
         if (n === undefined) return undefined;
         return this.comb(n).reduce((a, v) => a.concat(this.seed[v]), []);
@@ -321,9 +321,9 @@ export class Combination extends _CBase {
 /**
  * Base N
  */
-export class BaseN extends _CBase {
+export class BaseN<T> extends _CBase<T, T> {
     base: number;
-    constructor(seed: Iterable<any>, size = 1) {
+    constructor(seed: Iterable<T>, size = 1) {
         super();
         this.seed = [...seed];
         this.size = size;
@@ -334,7 +334,7 @@ export class BaseN extends _CBase {
         this.length = _crop(length);
         Object.freeze(this);
     }
-    nth(n: anyint): Optional<any[]> {
+    nth(n: anyint): Optional<T[]> {
         n = this._check(n);
         if (n === undefined) return undefined;
         let bn = _BI(n);
@@ -352,15 +352,15 @@ export class BaseN extends _CBase {
 /**
  * Power Set
  */
-export class PowerSet extends _CBase {
-    constructor(seed: Iterable<any>) {
+export class PowerSet<T> extends _CBase<T, T> {
+    constructor(seed: Iterable<T>) {
         super();
         this.seed = [...seed];
         const length = _BI(1) << _BI(this.seed.length);
         this.length = _crop(length);
         Object.freeze(this);
     }
-    nth(n: anyint): Optional<any[]> {
+    nth(n: anyint): Optional<T[]> {
         n = this._check(n);
         if (n === undefined) return undefined;
         let bn = _BI(n);
@@ -374,8 +374,8 @@ export class PowerSet extends _CBase {
 /**
  * Cartesian Product
  */
-export class CartesianProduct extends _CBase {
-    constructor(...args: Iterable<any>[]) {
+export class CartesianProduct<T> extends _CBase<T[], T> {
+    constructor(...args: Iterable<T>[]) {
         super();
         this.seed = args.map(v => [...v]);
         this.size = this.seed.length;
@@ -383,7 +383,7 @@ export class CartesianProduct extends _CBase {
         this.length = _crop(length);
         Object.freeze(this);
     }
-    nth(n: anyint): Optional<any[]> {
+    nth(n: anyint): Optional<T[]> {
         n = this._check(n);
         if (n === undefined) return undefined;
         let bn = _BI(n);


### PR DESCRIPTION
This pull request replaces instances of `any` in `combinatorics.ts` with generics for better type safety. 🙂 Note that this might be considered a breaking change for any dependents that do not use robust types.