### PR TITLE
fix: package.json type should be module

### DIFF
--- a/commonjs/package.json
+++ b/commonjs/package.json
@@ -1,0 +1,1 @@
+{"type":"commonjs"}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "js-combinatorics",
   "version": "1.5.4",
   "description": "Simple combinatorics like power set, combination, and permutation in JavaScript",
+  "type": "module",
   "main": "combinatorics.js",
   "module": "combinatorics.js",
   "exports": {


### PR DESCRIPTION
@dankogai

See https://nodejs.org/api/packages.html#determining-module-system but we either need to name the output file `.mjs` or set the type field in package.json to allow this to work with ESM.

> Node.js will treat as CommonJS all other forms of input, such as .js files where the nearest parent package.json file contains no top-level "type" field, or string input without the flag --input-type. This behavior is to preserve backward compatibility. However, now that Node.js supports both CommonJS and ES modules, it is best to be explicit whenever possible. Node.js will treat the following as CommonJS when passed to node as the initial input, or when referenced by import statements within ES module code: