### PR TITLE
Fix CommonJS export

### DIFF
--- a/commonjs/package.json
+++ b/commonjs/package.json
@@ -1,0 +1,3 @@
+{
+    "type": "commonjs"
+}


### PR DESCRIPTION
This small fix addresses the CommonJS error introduced in https://github.com/dankogai/js-combinatorics/commit/591b4e47685642dc001b203c8f53f40341e71938
```
Error [ERR_REQUIRE_ESM]: require() of ES Module

combinatorics.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which declares all .js files in that package scope as ES modules.
Instead rename combinatorics.js to end in .cjs, change the requiring code to use dynamic import() which is available in all CommonJS modules, or change "type": "module" to "type": "commonjs" in package.json to treat all .js files as CommonJS (using .mjs for all ES modules instead).
```

Can be tested with the following example:

`package.json`
```
{
  "dependencies": {
    "js-combinatorics": "^1.5.5"
  }
}
```

`index.js`
```
const combinatorics = require("js-combinatorics");

console.log(combinatorics.version);
```

`node index.js`